### PR TITLE
Refine driver queries and add stream iteration helper

### DIFF
--- a/driver/client.go
+++ b/driver/client.go
@@ -1,0 +1,394 @@
+package driver
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"reflect"
+	"strings"
+)
+
+// Client is a high level HTTP client for the InceptionDB REST API.
+type Client struct {
+	baseURL    *url.URL
+	httpClient *http.Client
+}
+
+// Option configures a Client instance.
+type Option func(*Client)
+
+// WithHTTPClient overrides the default HTTP client used to perform requests.
+func WithHTTPClient(h *http.Client) Option {
+	return func(c *Client) {
+		c.httpClient = h
+	}
+}
+
+// NewClient creates a new Client pointing to the provided base URL.
+func NewClient(baseURL string, opts ...Option) (*Client, error) {
+	if strings.TrimSpace(baseURL) == "" {
+		return nil, errors.New("base URL is required")
+	}
+
+	parsed, err := url.Parse(baseURL)
+	if err != nil {
+		return nil, fmt.Errorf("parse base url: %w", err)
+	}
+	if parsed.Scheme == "" {
+		return nil, errors.New("base URL must include the scheme (http or https)")
+	}
+	if parsed.Host == "" {
+		return nil, errors.New("base URL must include the host")
+	}
+
+	c := &Client{
+		baseURL:    parsed,
+		httpClient: http.DefaultClient,
+	}
+	for _, opt := range opts {
+		if opt != nil {
+			opt(c)
+		}
+	}
+	if c.httpClient == nil {
+		c.httpClient = http.DefaultClient
+	}
+	return c, nil
+}
+
+// ListCollections retrieves the collections metadata available in the server.
+func (c *Client) ListCollections(ctx context.Context) ([]Collection, error) {
+	var collections []Collection
+	if err := c.doJSON(ctx, http.MethodGet, "/v1/collections", nil, &collections); err != nil {
+		return nil, err
+	}
+	return collections, nil
+}
+
+// CreateCollection creates a new collection and returns its metadata.
+func (c *Client) CreateCollection(ctx context.Context, req *CreateCollectionRequest) (*Collection, error) {
+	if req == nil {
+		return nil, errors.New("create collection request is nil")
+	}
+	body, err := encodeJSONPayload(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode create collection request: %w", err)
+	}
+	var result Collection
+	if err := c.doJSON(ctx, http.MethodPost, "/v1/collections", body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetCollection retrieves the metadata of a single collection.
+func (c *Client) GetCollection(ctx context.Context, collection string) (*Collection, error) {
+	var result Collection
+	if err := c.doJSON(ctx, http.MethodGet, collectionPath(collection), nil, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DropCollection deletes the collection and its indexes.
+func (c *Client) DropCollection(ctx context.Context, collection string) error {
+	return c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "dropCollection"), nil, nil)
+}
+
+// SetDefaults configures the default document used when inserting new rows.
+func (c *Client) SetDefaults(ctx context.Context, collection string, defaults map[string]any) (map[string]any, error) {
+	body, err := encodeJSONObject(defaults)
+	if err != nil {
+		return nil, fmt.Errorf("encode defaults request: %w", err)
+	}
+	result := map[string]any{}
+	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "setDefaults"), body, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// ListIndexes returns the indexes registered in a collection.
+func (c *Client) ListIndexes(ctx context.Context, collection string) ([]Index, error) {
+	var result []Index
+	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "listIndexes"), nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// CreateIndex registers a new index and returns its metadata.
+func (c *Client) CreateIndex(ctx context.Context, collection string, req *CreateIndexRequest) (*Index, error) {
+	if req == nil {
+		return nil, errors.New("create index request is nil")
+	}
+	body, err := encodeJSONPayload(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode create index request: %w", err)
+	}
+	var result Index
+	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "createIndex"), body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// GetIndex retrieves information about a single index.
+func (c *Client) GetIndex(ctx context.Context, collection, name string) (*Index, error) {
+	body, err := encodeJSONObject(map[string]string{"name": name})
+	if err != nil {
+		return nil, fmt.Errorf("encode get index request: %w", err)
+	}
+	var result Index
+	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "getIndex"), body, &result); err != nil {
+		return nil, err
+	}
+	return &result, nil
+}
+
+// DropIndex removes an index from a collection.
+func (c *Client) DropIndex(ctx context.Context, collection, name string) error {
+	body, err := encodeJSONObject(map[string]string{"name": name})
+	if err != nil {
+		return fmt.Errorf("encode drop index request: %w", err)
+	}
+	return c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "dropIndex"), body, nil)
+}
+
+// Size returns statistics about the collection usage. This endpoint is experimental.
+func (c *Client) Size(ctx context.Context, collection string) (map[string]any, error) {
+	result := map[string]any{}
+	if err := c.doJSON(ctx, http.MethodPost, collectionActionPath(collection, "size"), nil, &result); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// InsertStream sends the provided JSON Lines payload to the insert endpoint and
+// returns a stream with the inserted documents.
+func (c *Client) InsertStream(ctx context.Context, collection string, reader io.Reader) (*JSONStream, error) {
+	if reader == nil {
+		reader = http.NoBody
+	}
+	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "insert"), reader, "application/json")
+}
+
+// InsertDocuments is a convenience helper that encodes the provided documents as
+// JSON Lines before sending them to the server.
+func (c *Client) InsertDocuments(ctx context.Context, collection string, documents ...any) (*JSONStream, error) {
+	var reader io.Reader
+	if len(documents) > 0 {
+		r, err := encodeJSONLines(documents)
+		if err != nil {
+			return nil, fmt.Errorf("encode insert payload: %w", err)
+		}
+		reader = r
+	}
+	return c.InsertStream(ctx, collection, reader)
+}
+
+// Find executes a query against the collection and streams the matching
+// documents.
+func (c *Client) Find(ctx context.Context, collection string, req *FindRequest) (*JSONStream, error) {
+	body, err := encodeQueryRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode find request: %w", err)
+	}
+	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "find"), body, "application/json")
+}
+
+// Patch applies a partial update to the documents matched by the query and
+// streams each patched document.
+func (c *Client) Patch(ctx context.Context, collection string, req *PatchRequest) (*JSONStream, error) {
+	if req == nil {
+		return nil, errors.New("patch request is nil")
+	}
+	body, err := encodeQueryRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode patch request: %w", err)
+	}
+	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "patch"), body, "application/json")
+}
+
+// Remove deletes the documents matched by the query and streams the removed
+// documents back to the caller.
+func (c *Client) Remove(ctx context.Context, collection string, req *RemoveRequest) (*JSONStream, error) {
+	body, err := encodeQueryRequest(req)
+	if err != nil {
+		return nil, fmt.Errorf("encode remove request: %w", err)
+	}
+	return c.stream(ctx, http.MethodPost, collectionActionPath(collection, "remove"), body, "application/json")
+}
+
+func (c *Client) stream(ctx context.Context, method, path string, body io.Reader, contentType string) (*JSONStream, error) {
+	resp, err := c.do(ctx, method, path, body, contentType)
+	if err != nil {
+		return nil, err
+	}
+	return newJSONStream(resp), nil
+}
+
+func (c *Client) doJSON(ctx context.Context, method, path string, body io.Reader, dest any) error {
+	resp, err := c.do(ctx, method, path, body, "")
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	if dest == nil || resp.StatusCode == http.StatusNoContent {
+		io.Copy(io.Discard, resp.Body)
+		return nil
+	}
+
+	dec := json.NewDecoder(resp.Body)
+	if err := dec.Decode(dest); err != nil {
+		if errors.Is(err, io.EOF) {
+			return nil
+		}
+		return err
+	}
+	io.Copy(io.Discard, resp.Body)
+	return nil
+}
+
+func (c *Client) do(ctx context.Context, method, path string, body io.Reader, contentType string) (*http.Response, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	rel, err := url.Parse(path)
+	if err != nil {
+		return nil, fmt.Errorf("invalid path %q: %w", path, err)
+	}
+	endpoint := c.baseURL.ResolveReference(rel)
+
+	req, err := http.NewRequestWithContext(ctx, method, endpoint.String(), body)
+	if err != nil {
+		return nil, err
+	}
+
+	if contentType == "" && body != nil {
+		contentType = "application/json"
+	}
+	if contentType != "" {
+		req.Header.Set("Content-Type", contentType)
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode >= 400 {
+		defer resp.Body.Close()
+		return nil, parseErrorResponse(resp)
+	}
+
+	return resp, nil
+}
+
+func collectionPath(collection string) string {
+	return "/v1/collections/" + url.PathEscape(collection)
+}
+
+func collectionActionPath(collection, action string) string {
+	return collectionPath(collection) + ":" + action
+}
+
+func encodeJSONPayload(payload any) (io.Reader, error) {
+	if payload == nil {
+		return nil, nil
+	}
+	switch v := payload.(type) {
+	case io.Reader:
+		return v, nil
+	case []byte:
+		data := make([]byte, len(v))
+		copy(data, v)
+		return bytes.NewReader(data), nil
+	case string:
+		return strings.NewReader(v), nil
+	case json.RawMessage:
+		data := make([]byte, len(v))
+		copy(data, v)
+		return bytes.NewReader(data), nil
+	default:
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(data), nil
+	}
+}
+
+func encodeJSONObject(payload any) (io.Reader, error) {
+	switch v := payload.(type) {
+	case nil:
+		return bytes.NewReader([]byte("{}")), nil
+	case io.Reader:
+		return v, nil
+	case []byte:
+		trimmed := bytes.TrimSpace(v)
+		if len(trimmed) == 0 {
+			return bytes.NewReader([]byte("{}")), nil
+		}
+		data := make([]byte, len(v))
+		copy(data, v)
+		return bytes.NewReader(data), nil
+	case string:
+		if strings.TrimSpace(v) == "" {
+			return bytes.NewReader([]byte("{}")), nil
+		}
+		return strings.NewReader(v), nil
+	case json.RawMessage:
+		return encodeJSONObject([]byte(v))
+	default:
+		val := reflect.ValueOf(payload)
+		switch val.Kind() { //nolint:exhaustive // interested in composite types.
+		case reflect.Map:
+			if val.IsNil() {
+				return bytes.NewReader([]byte("{}")), nil
+			}
+		case reflect.Pointer, reflect.Interface:
+			if val.IsNil() {
+				return bytes.NewReader([]byte("{}")), nil
+			}
+		}
+		data, err := json.Marshal(v)
+		if err != nil {
+			return nil, err
+		}
+		return bytes.NewReader(data), nil
+	}
+}
+
+func encodeJSONLines(items []any) (io.Reader, error) {
+	buf := &bytes.Buffer{}
+	enc := json.NewEncoder(buf)
+	enc.SetEscapeHTML(false)
+	for _, item := range items {
+		if err := enc.Encode(item); err != nil {
+			return nil, err
+		}
+	}
+	return buf, nil
+}
+
+func encodeQueryRequest(payload any) (io.Reader, error) {
+	if payload == nil {
+		return bytes.NewReader([]byte("{}")), nil
+	}
+	val := reflect.ValueOf(payload)
+	switch val.Kind() { //nolint:exhaustive // only care about pointer-like kinds.
+	case reflect.Pointer, reflect.Interface:
+		if val.IsNil() {
+			return bytes.NewReader([]byte("{}")), nil
+		}
+	}
+	return encodeJSONObject(payload)
+}

--- a/driver/client_test.go
+++ b/driver/client_test.go
@@ -1,0 +1,54 @@
+package driver
+
+import (
+	"encoding/json"
+	"io"
+	"testing"
+)
+
+func TestEncodeQueryRequestNil(t *testing.T) {
+	reader, err := encodeQueryRequest((*FindRequest)(nil))
+	if err != nil {
+		t.Fatalf("encodeQueryRequest() error = %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if got := string(data); got != "{}" {
+		t.Fatalf("encodeQueryRequest() = %s, want {}", got)
+	}
+}
+
+func TestEncodeQueryRequestPayload(t *testing.T) {
+	req := &FindRequest{
+		QueryOptions: QueryOptions{
+			Index:  "my-index",
+			Limit:  5,
+			Filter: map[string]any{"name": "Fulanez"},
+		},
+	}
+	reader, err := encodeQueryRequest(req)
+	if err != nil {
+		t.Fatalf("encodeQueryRequest() error = %v", err)
+	}
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+
+	payload := map[string]any{}
+	if err := json.Unmarshal(data, &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if got := payload["index"]; got != req.Index {
+		t.Fatalf("index = %v, want %s", got, req.Index)
+	}
+	if got := payload["limit"]; got != float64(req.Limit) {
+		t.Fatalf("limit = %v, want %d", got, req.Limit)
+	}
+	if _, ok := payload["filter"].(map[string]any); !ok {
+		t.Fatalf("filter type = %T, want map[string]any", payload["filter"])
+	}
+}

--- a/driver/errors.go
+++ b/driver/errors.go
@@ -1,0 +1,65 @@
+package driver
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const maxErrorBody = 1 << 20 // 1MiB should be more than enough for error messages.
+
+// Error represents an HTTP level error returned by the server.
+type Error struct {
+	StatusCode  int
+	Message     string
+	Description string
+	Body        []byte
+}
+
+func (e *Error) Error() string {
+	status := http.StatusText(e.StatusCode)
+	if status == "" {
+		status = fmt.Sprintf("status %d", e.StatusCode)
+	}
+	if e.Message == "" {
+		if len(strings.TrimSpace(string(e.Body))) > 0 {
+			return fmt.Sprintf("inceptiondb: %s: %s", status, strings.TrimSpace(string(e.Body)))
+		}
+		return fmt.Sprintf("inceptiondb: %s", status)
+	}
+	if e.Description != "" {
+		return fmt.Sprintf("inceptiondb: %s: %s (%s)", status, e.Message, e.Description)
+	}
+	return fmt.Sprintf("inceptiondb: %s: %s", status, e.Message)
+}
+
+func parseErrorResponse(resp *http.Response) error {
+	data, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBody))
+	if err != nil {
+		return &Error{StatusCode: resp.StatusCode, Body: data, Message: err.Error()}
+	}
+
+	var payload struct {
+		Error struct {
+			Message     string `json:"message"`
+			Description string `json:"description"`
+		} `json:"error"`
+	}
+	if len(data) > 0 {
+		if err := json.Unmarshal(data, &payload); err == nil {
+			if payload.Error.Message != "" || payload.Error.Description != "" {
+				return &Error{
+					StatusCode:  resp.StatusCode,
+					Message:     payload.Error.Message,
+					Description: payload.Error.Description,
+					Body:        data,
+				}
+			}
+		}
+	}
+
+	message := strings.TrimSpace(string(data))
+	return &Error{StatusCode: resp.StatusCode, Message: message, Body: data}
+}

--- a/driver/stream.go
+++ b/driver/stream.go
@@ -1,0 +1,97 @@
+package driver
+
+import (
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+)
+
+// JSONStream wraps a streaming JSON Lines response.
+type JSONStream struct {
+	resp   *http.Response
+	dec    *json.Decoder
+	closed bool
+}
+
+// ErrStopIteration signals that a JSON stream iteration should stop without
+// treating it as an error.
+var ErrStopIteration = errors.New("driver: stop iteration")
+
+func newJSONStream(resp *http.Response) *JSONStream {
+	return &JSONStream{
+		resp: resp,
+		dec:  json.NewDecoder(resp.Body),
+	}
+}
+
+// Close stops the stream and releases the underlying HTTP resources.
+func (s *JSONStream) Close() error {
+	if s == nil || s.closed {
+		return nil
+	}
+	s.closed = true
+	return s.resp.Body.Close()
+}
+
+// Next decodes the next JSON value from the stream into v. It returns io.EOF
+// when no more items are available.
+func (s *JSONStream) Next(v any) error {
+	if s == nil {
+		return errors.New("nil stream")
+	}
+	if s.closed {
+		return io.EOF
+	}
+	if err := s.dec.Decode(v); err != nil {
+		if errors.Is(err, io.EOF) {
+			s.Close()
+			return io.EOF
+		}
+		s.Close()
+		return err
+	}
+	return nil
+}
+
+// Iterate decodes each JSON value into a typed destination and invokes fn for
+// every item until the stream ends, fn returns ErrStopIteration or an error is
+// encountered. Iterate stops consuming the stream as soon as fn returns an
+// error.
+func Iterate[T any](s *JSONStream, fn func(*T) error) error {
+	if s == nil {
+		return errors.New("nil stream")
+	}
+	if fn == nil {
+		return errors.New("nil iterator callback")
+	}
+
+	for {
+		var item T
+		if err := s.Next(&item); err != nil {
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		if err := fn(&item); err != nil {
+			if errors.Is(err, ErrStopIteration) {
+				if cerr := s.Close(); cerr != nil && !errors.Is(cerr, io.EOF) {
+					return cerr
+				}
+				return nil
+			}
+			s.Close()
+			return err
+		}
+	}
+}
+
+// StatusCode returns the HTTP status code associated with the stream.
+func (s *JSONStream) StatusCode() int {
+	if s == nil || s.resp == nil {
+		return 0
+	}
+	return s.resp.StatusCode
+}

--- a/driver/stream_test.go
+++ b/driver/stream_test.go
@@ -1,0 +1,70 @@
+package driver
+
+import (
+	"io"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+type testDocument struct {
+	ID int `json:"id"`
+}
+
+func newTestStream(t *testing.T, payload string) *JSONStream {
+	t.Helper()
+	resp := &http.Response{
+		StatusCode: http.StatusOK,
+		Body:       io.NopCloser(strings.NewReader(payload)),
+	}
+	return newJSONStream(resp)
+}
+
+func TestJSONStreamIterate(t *testing.T) {
+	stream := newTestStream(t, "{\"id\":1}\n{\"id\":2}\n")
+
+	var ids []int
+	if err := Iterate(stream, func(doc *testDocument) error {
+		ids = append(ids, doc.ID)
+		return nil
+	}); err != nil {
+		t.Fatalf("Iterate() error = %v", err)
+	}
+
+	expected := []int{1, 2}
+	if !reflect.DeepEqual(ids, expected) {
+		t.Fatalf("Iterate() collected %v, want %v", ids, expected)
+	}
+}
+
+func TestJSONStreamIterateStop(t *testing.T) {
+	stream := newTestStream(t, "{\"id\":1}\n{\"id\":2}\n")
+
+	var ids []int
+	if err := Iterate(stream, func(doc *testDocument) error {
+		ids = append(ids, doc.ID)
+		return ErrStopIteration
+	}); err != nil {
+		t.Fatalf("Iterate() error = %v", err)
+	}
+
+	expected := []int{1}
+	if !reflect.DeepEqual(ids, expected) {
+		t.Fatalf("Iterate() collected %v, want %v", ids, expected)
+	}
+}
+
+func TestJSONStreamIterateNilCallback(t *testing.T) {
+	stream := newTestStream(t, "{\"id\":1}\n")
+	if err := Iterate[testDocument](stream, nil); err == nil {
+		t.Fatal("Iterate() expected error for nil callback")
+	}
+}
+
+func TestJSONStreamIterateNilStream(t *testing.T) {
+	var stream *JSONStream
+	if err := Iterate(stream, func(doc *testDocument) error { return nil }); err == nil {
+		t.Fatal("Iterate() expected error for nil stream")
+	}
+}

--- a/driver/types.go
+++ b/driver/types.go
@@ -1,0 +1,114 @@
+package driver
+
+import "encoding/json"
+
+// Collection describes a collection metadata entry returned by the API.
+type Collection struct {
+	Name     string         `json:"name"`
+	Total    int            `json:"total"`
+	Indexes  int            `json:"indexes"`
+	Defaults map[string]any `json:"defaults,omitempty"`
+}
+
+// CreateCollectionRequest contains the payload required to create a
+// collection.
+type CreateCollectionRequest struct {
+	Name     string         `json:"name"`
+	Defaults map[string]any `json:"defaults,omitempty"`
+}
+
+// Index describes an index configuration as returned by the API. Dynamic
+// options are stored inside Options.
+type Index struct {
+	Name    string         `json:"name"`
+	Type    string         `json:"type"`
+	Options map[string]any `json:"-"`
+}
+
+// MarshalJSON flattens the index options so the payload matches the HTTP API.
+func (i Index) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, len(i.Options)+2)
+	m["name"] = i.Name
+	m["type"] = i.Type
+	for k, v := range i.Options {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+// UnmarshalJSON extracts the name and type fields while keeping the rest of the
+// payload inside Options.
+func (i *Index) UnmarshalJSON(data []byte) error {
+	raw := map[string]any{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+
+	if v, ok := raw["name"].(string); ok {
+		i.Name = v
+	}
+	if v, ok := raw["type"].(string); ok {
+		i.Type = v
+	}
+	delete(raw, "name")
+	delete(raw, "type")
+	if len(raw) == 0 {
+		i.Options = nil
+	} else {
+		i.Options = raw
+	}
+	return nil
+}
+
+// CreateIndexRequest captures the parameters used to create an index. The
+// Options map is flattened when marshalled so it matches the HTTP API format.
+type CreateIndexRequest struct {
+	Name    string         `json:"name"`
+	Type    string         `json:"type"`
+	Options map[string]any `json:"options,omitempty"`
+}
+
+// MarshalJSON flattens Options to the top-level keys expected by the API.
+func (r CreateIndexRequest) MarshalJSON() ([]byte, error) {
+	m := make(map[string]any, len(r.Options)+2)
+	if r.Name != "" {
+		m["name"] = r.Name
+	}
+	if r.Type != "" {
+		m["type"] = r.Type
+	}
+	for k, v := range r.Options {
+		m[k] = v
+	}
+	return json.Marshal(m)
+}
+
+// QueryOptions represents the shared query parameters used by find, patch and
+// remove operations.
+type QueryOptions struct {
+	Mode    string         `json:"mode,omitempty"`
+	Index   string         `json:"index,omitempty"`
+	Filter  map[string]any `json:"filter,omitempty"`
+	Skip    int64          `json:"skip,omitempty"`
+	Limit   int64          `json:"limit,omitempty"`
+	Reverse bool           `json:"reverse,omitempty"`
+	From    map[string]any `json:"from,omitempty"`
+	To      map[string]any `json:"to,omitempty"`
+	Value   string         `json:"value,omitempty"`
+}
+
+// FindRequest captures the options available when querying documents.
+type FindRequest struct {
+	QueryOptions
+}
+
+// PatchRequest describes the payload required to patch documents.
+type PatchRequest struct {
+	QueryOptions
+	Patch any `json:"patch"`
+}
+
+// RemoveRequest contains the parameters accepted by the remove endpoint.
+type RemoveRequest struct {
+	QueryOptions
+}


### PR DESCRIPTION
## Summary
- replace untyped query parameters with explicit request structures and encoding helpers for find/patch/remove
- add a generic JSON stream iterator with a stop sentinel to ease typed streaming consumption
- cover the new helpers with focused unit tests

## Testing
- go test ./...


------
https://chatgpt.com/codex/tasks/task_e_68cccfbd5908832b9cefcd65cfd82ed7