### PR TITLE
Add UI for managing collection indexes

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,10 +4,10 @@
 
 * Implementar layout general (sólo front)
 * Añadir un indicador de estado de conexión con el backend (sólo front)
+* Implementar gestión de índices (sólo front)
 
 ## Next features
 
-* Implementar gestión de índices (sólo front)
 * Implementar edición de items (sólo front)
 * Mejorar la paginación (ver los campos skip y limit pero añadir botones de flechas next previous) (sólo front)
 * Implementar un log con el histórico de llamadas (sólo front)
@@ -15,6 +15,9 @@
 * Añadir un mensaje de bienvenida explicando las motivaciones del proyecto (sólo front)
 * Implementar exportación de resultados a JSON (sólo front)
 * Implementar guardado de consultas frecuentes (sólo front)
+* Implementar vista tabular alterna para resultados (sólo front)
+* Añadir buscador de colecciones (sólo front)
+* Implementar ayuda contextual para filtros (sólo front)
 
 ## Will not do these features
 

--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -306,19 +306,134 @@
               </div>
 
               <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Índices</h3>
-                <div v-if="indexesLoading" class="text-sm text-slate-400">Cargando índices…</div>
-                <div v-else-if="indexes.length === 0" class="text-sm text-slate-400">La colección no tiene índices definidos.</div>
-                <ul v-else class="space-y-3 text-sm text-slate-300">
-                  <li v-for="index in indexes" :key="index.name" class="rounded-lg border border-slate-800 bg-slate-950 p-3">
-                    <div class="flex items-center justify-between">
-                      <span class="font-semibold">{{ index.name }}</span>
-                      <span class="text-xs uppercase tracking-wide text-slate-500">{{ index.type }}</span>
+                <div class="flex items-center justify-between gap-3">
+                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Indexes</h3>
+                  <button
+                    type="button"
+                    class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
+                    @click="toggleIndexForm"
+                  >
+                    {{ indexForm.open ? 'Cancel' : 'New index' }}
+                  </button>
+                </div>
+                <p v-if="indexMessages.error" class="text-sm text-rose-400">{{ indexMessages.error }}</p>
+                <p v-else-if="indexMessages.success" class="text-sm text-emerald-400">{{ indexMessages.success }}</p>
+                <form
+                  v-if="indexForm.open"
+                  class="space-y-3 rounded-lg border border-slate-800/70 bg-slate-950/60 p-4"
+                  @submit.prevent="createIndex"
+                >
+                  <div>
+                    <label for="index-name" class="block text-xs uppercase tracking-wide text-slate-400">Name</label>
+                    <input
+                      id="index-name"
+                      v-model="indexForm.name"
+                      type="text"
+                      required
+                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                      placeholder="by_email"
+                    >
+                  </div>
+                  <div>
+                    <label for="index-type" class="block text-xs uppercase tracking-wide text-slate-400">Type</label>
+                    <select
+                      id="index-type"
+                      v-model="indexForm.type"
+                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    >
+                      <option value="map">Map</option>
+                      <option value="btree">B-Tree</option>
+                    </select>
+                  </div>
+                  <div v-if="indexForm.type === 'map'" class="space-y-2">
+                    <div>
+                      <label for="index-field" class="block text-xs uppercase tracking-wide text-slate-400">Field</label>
+                      <input
+                        id="index-field"
+                        v-model="indexForm.field"
+                        type="text"
+                        required
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                        placeholder="email"
+                      >
                     </div>
-                    <p v-if="index.type === 'map'" class="mt-1 text-xs text-slate-400">Campo: {{ index.field }}</p>
-                    <p v-else-if="index.type === 'btree'" class="mt-1 text-xs text-slate-400">Campos: {{ index.fields.join(', ') }}</p>
-                    <p v-if="index.unique" class="mt-1 text-xs text-emerald-400">Único</p>
-                    <p v-if="index.sparse" class="mt-1 text-xs text-slate-500">Sparse</p>
+                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                      <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                      Sparse (ignore documents without the field)
+                    </label>
+                  </div>
+                  <div v-else class="space-y-2">
+                    <div>
+                      <label for="index-fields" class="block text-xs uppercase tracking-wide text-slate-400">Fields</label>
+                      <input
+                        id="index-fields"
+                        v-model="indexForm.fieldsText"
+                        type="text"
+                        required
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                        placeholder="lastName, firstName"
+                      >
+                      <p class="mt-1 text-[11px] text-slate-500">
+                        Separate fields with commas. Prefix with "-" for descending order.
+                      </p>
+                    </div>
+                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                      <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                      Sparse (ignore documents missing the fields)
+                    </label>
+                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                      <input type="checkbox" v-model="indexForm.unique" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                      Unique (reject duplicate combinations)
+                    </label>
+                  </div>
+                  <div class="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
+                      @click="toggleIndexForm"
+                    >
+                      Cancel
+                    </button>
+                    <button
+                      type="submit"
+                      class="rounded-md bg-sky-600 px-3 py-2 text-xs font-semibold text-white hover:bg-sky-500 transition disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="indexForm.submitting"
+                    >
+                      {{ indexForm.submitting ? 'Creating…' : 'Create index' }}
+                    </button>
+                  </div>
+                </form>
+                <div v-if="indexesLoading" class="text-sm text-slate-400">Loading indexes…</div>
+                <div v-else-if="indexes.length === 0" class="text-sm text-slate-400">This collection has no indexes yet.</div>
+                <ul v-else class="space-y-3 text-sm text-slate-300">
+                  <li
+                    v-for="index in indexes"
+                    :key="index.name"
+                    class="rounded-lg border border-slate-800 bg-slate-950 p-3"
+                  >
+                    <div class="flex items-start justify-between gap-3">
+                      <div class="space-y-2">
+                        <div class="flex items-center gap-2 text-slate-200">
+                          <span class="font-semibold">{{ index.name }}</span>
+                          <span class="rounded-full border border-slate-700/80 bg-slate-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-slate-400">
+                            {{ index.type === 'btree' ? 'B-Tree' : 'Map' }}
+                          </span>
+                        </div>
+                        <p v-if="index.type === 'map'" class="text-xs text-slate-400">Field: {{ index.field }}</p>
+                        <p v-else-if="index.type === 'btree'" class="text-xs text-slate-400">Fields: {{ Array.isArray(index.fields) ? index.fields.join(', ') : '' }}</p>
+                        <div class="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide text-slate-400">
+                          <span v-if="index.unique" class="rounded bg-slate-800 px-2 py-0.5 text-emerald-300/90">Unique</span>
+                          <span v-if="index.sparse" class="rounded bg-slate-800 px-2 py-0.5 text-slate-200/80">Sparse</span>
+                        </div>
+                      </div>
+                      <button
+                        type="button"
+                        class="rounded-md border border-rose-500/40 bg-rose-600/20 px-2 py-1 text-xs font-semibold text-rose-200 hover:bg-rose-600/30 transition"
+                        @click="removeIndex(index)"
+                      >
+                        Delete
+                      </button>
+                    </div>
                   </li>
                 </ul>
               </div>
@@ -355,6 +470,17 @@
           const rangeTo = reactive({});
           const insertForm = reactive({ payload: '{\n\n}', error: '', success: '' });
           const createForm = reactive({ open: false, name: '', error: '' });
+          const indexForm = reactive({
+            open: false,
+            name: '',
+            type: 'map',
+            field: '',
+            fieldsText: '',
+            sparse: false,
+            unique: false,
+            submitting: false,
+          });
+          const indexMessages = reactive({ error: '', success: '' });
           const connectionStatus = reactive({
             state: 'unknown',
             detail: 'Waiting for first response.',
@@ -456,6 +582,108 @@
             createForm.error = '';
           };
 
+          const resetIndexForm = () => {
+            indexForm.name = '';
+            indexForm.type = 'map';
+            indexForm.field = '';
+            indexForm.fieldsText = '';
+            indexForm.sparse = false;
+            indexForm.unique = false;
+            indexForm.submitting = false;
+          };
+
+          const toggleIndexForm = () => {
+            if (indexForm.open) {
+              indexForm.open = false;
+            } else {
+              resetIndexForm();
+              indexForm.open = true;
+            }
+            indexMessages.error = '';
+            indexMessages.success = '';
+          };
+
+          const createIndex = async () => {
+            if (!selectedCollection.value || indexForm.submitting) return;
+            indexMessages.error = '';
+            indexMessages.success = '';
+            const name = indexForm.name.trim();
+            if (!name) {
+              indexMessages.error = 'Provide a name for the index.';
+              return;
+            }
+            const payload = {
+              name,
+              type: indexForm.type,
+            };
+            if (indexForm.type === 'map') {
+              const field = indexForm.field.trim();
+              if (!field) {
+                indexMessages.error = 'Provide the field to index.';
+                return;
+              }
+              payload.field = field;
+              payload.sparse = !!indexForm.sparse;
+            } else if (indexForm.type === 'btree') {
+              const fields = indexForm.fieldsText
+                .split(',')
+                .map((part) => part.trim())
+                .filter(Boolean);
+              if (!fields.length) {
+                indexMessages.error = 'Add at least one field for the index.';
+                return;
+              }
+              payload.fields = fields;
+              payload.sparse = !!indexForm.sparse;
+              payload.unique = !!indexForm.unique;
+            } else {
+              indexMessages.error = 'Unsupported index type.';
+              return;
+            }
+            indexForm.submitting = true;
+            try {
+              await axios.post(
+                `/v1/collections/${encodeURIComponent(selectedCollection.value.name)}:createIndex`,
+                payload,
+              );
+              markConnectionOnline();
+              indexMessages.success = `Index "${name}" created successfully.`;
+              indexForm.open = false;
+              resetIndexForm();
+              await loadIndexes();
+              selectedIndexName.value = name;
+            } catch (error) {
+              indexMessages.error = error?.response?.data?.error || 'Failed to create the index.';
+              handleRequestError(error);
+            } finally {
+              indexForm.submitting = false;
+            }
+          };
+
+          const removeIndex = async (index) => {
+            if (!selectedCollection.value) return;
+            indexMessages.error = '';
+            indexMessages.success = '';
+            const confirmMessage = `Delete the index "${index.name}"? This action cannot be undone.`;
+            const ok = window.confirm(confirmMessage);
+            if (!ok) return;
+            try {
+              await axios.post(
+                `/v1/collections/${encodeURIComponent(selectedCollection.value.name)}:dropIndex`,
+                { name: index.name },
+              );
+              markConnectionOnline();
+              if (selectedIndexName.value === index.name) {
+                selectedIndexName.value = '';
+              }
+              indexMessages.success = `Index "${index.name}" deleted successfully.`;
+              await loadIndexes();
+            } catch (error) {
+              indexMessages.error = error?.response?.data?.error || 'Failed to delete the index.';
+              handleRequestError(error);
+            }
+          };
+
           const markConnectionOnline = (detail = 'All systems operational') => {
             connectionStatus.state = 'online';
             connectionStatus.detail = detail;
@@ -547,6 +775,17 @@
             }
           };
 
+          watch(
+            () => indexForm.type,
+            () => {
+              indexForm.field = '';
+              indexForm.fieldsText = '';
+              indexForm.sparse = false;
+              indexForm.unique = false;
+              indexMessages.error = '';
+            },
+          );
+
           watch(activeIndex, () => {
             mapValue.value = '';
             reverse.value = false;
@@ -566,6 +805,10 @@
             queryError.value = '';
             queryStats.elapsed = '';
             queryStats.returned = 0;
+            indexForm.open = false;
+            resetIndexForm();
+            indexMessages.error = '';
+            indexMessages.success = '';
             if (collection) {
               await loadIndexes();
               await runQuery();
@@ -882,6 +1125,8 @@
             reverse,
             rangeFrom,
             rangeTo,
+            indexForm,
+            indexMessages,
             insertForm,
             createForm,
             connectionStatus,
@@ -902,10 +1147,13 @@
             prettyTotal,
             isSelected,
             toggleCreateForm,
+            toggleIndexForm,
             selectCollection,
             runQuery,
             nextPage,
             prevPage,
+            createIndex,
+            removeIndex,
             insertDocument,
             createCollection,
             dropCollection,


### PR DESCRIPTION
## Summary
- move the index management feature to the roadmap's completed list and add new frontend ideas to "Next features"
- add a Vue-powered form that lets users create B-Tree and map indexes with validation and feedback
- allow deleting indexes from the UI and integrate the new state with existing selection logic

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68d9d26317d4832ba6e63cb6a51d119b