### PR TITLE
Enable document deletion by ID in the console

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -8,9 +8,12 @@
 * Traducir toda la interfaz a inglés americano (sólo front)
 * Implementar un log con el histórico de llamadas (sólo front)
 * Implementar edición de documentos (sólo front)
+* Implementar el botón de eliminar documentos por ID (sólo front)
 
 ## Next features
 
+* Implementar buscador rápido por ID de documento en la vista principal (sólo front)
+* Añadir notificaciones emergentes para operaciones CRUD exitosas o fallidas (sólo front)
 * Añadir validación visual inmediata para filtros e inserciones JSON (sólo front)
 * Implementar vista detallada de documentos con navegación entre resultados (sólo front)
 * Mejorar la paginación (ver los campos skip y limit pero añadir botones de flechas next previous) (sólo front)

--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -323,14 +323,8 @@
                         </p>
                       </div>
                       <pre class="whitespace-pre-wrap break-words text-sm text-slate-200 font-mono">{{ formatDocument(row) }}</pre>
-                      <p v-if="!canDeleteRow(row) && activeIndex && activeIndex.type === 'map'" class="mt-3 text-xs text-slate-500">
-                        The document does not contain the "{{ activeIndex.field }}" field required for deletion.
-                      </p>
-                      <p v-else-if="activeIndex && activeIndex.type !== 'map'" class="mt-3 text-xs text-slate-500">
-                        Select a "map" index to enable direct deletion.
-                      </p>
                       <p v-if="!canEditDocument(row)" class="mt-3 text-xs text-slate-500">
-                        The document must include an "id" field to enable editing.
+                        The document must include an "id" field to enable editing or deletion.
                       </p>
                     </div>
                   </div>
@@ -1460,40 +1454,32 @@
             runQuery();
           });
 
-          const canDeleteRow = (row) => {
-            const index = activeIndex.value;
-            if (!index || index.type !== 'map') return false;
-            const field = index.field;
-            if (!field) return false;
-            return Object.prototype.hasOwnProperty.call(row, field);
-          };
+          const canDeleteRow = (row) => documentId(row) !== null;
 
           const deleteRow = async (row) => {
-            const index = activeIndex.value;
-            if (!selectedCollection.value || !index || index.type !== 'map' || !index.field) return;
-            const value = row[index.field];
-            if (value === undefined) {
-              queryError.value = `The document does not contain the field "${index.field}".`;
+            if (!selectedCollection.value) return;
+            const id = documentId(row);
+            if (!id) {
+              queryError.value = 'The document does not contain an "id" field.';
               return;
             }
-            const ok = window.confirm(`Delete the document where ${index.field} = ${value}?`);
+            const ok = window.confirm(`Delete the document with id ${id}?`);
             if (!ok) return;
             const url = `/v1/collections/${encodeURIComponent(selectedCollection.value.name)}:remove`;
             const entry = createActivityEntry({
-              label: `Delete document by ${index.field}`,
+              label: `Delete document ${id}`,
               method: 'POST',
               url,
               target: selectedCollection.value.name,
             });
             try {
               const resp = await axios.post(url, {
-                mode: 'unique',
-                field: index.field,
-                value,
+                filter: { id: row.id },
+                limit: 1,
               });
               markConnectionOnline();
               completeActivityEntry(entry, {
-                detail: `Deleted document where ${index.field} = ${value}.`,
+                detail: `Deleted document with id ${id}.`,
                 statusCode: resp.status,
               });
               await runQuery();


### PR DESCRIPTION
## Summary
- allow deleting documents directly by their `id` without requiring a map index in the results list
- clarify the helper text when documents do not expose an `id`
- update the roadmap to record the delivered deletion feature and note the next priorities

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68daa273a7d4832b8534d86d5b2d1f27