### PR TITLE
Add tooltip to results header

### DIFF
--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -301,8 +301,16 @@
                 >
                   <div class="flex flex-col gap-3 md:flex-row md:items-start md:justify-between">
                     <div>
-                      <p class="text-sm font-semibold text-slate-200">Results</p>
-                      <p class="text-xs text-slate-400">Switch between JSON cards and a table layout to review your documents.</p>
+                      <p class="text-sm font-semibold text-slate-200 flex items-center gap-1">
+                        <span>Results</span>
+                        <span
+                          class="cursor-help"
+                          title="Switch between JSON cards and a table layout to review your documents."
+                          aria-label="More information about results view options"
+                        >
+                          🛈
+                        </span>
+                      </p>
                     </div>
                     <div class="flex flex-col items-stretch gap-2 text-right md:items-end">
                       <div


### PR DESCRIPTION
## Summary
- display the Results heading with an info icon
- show the existing description as a tooltip on the info icon

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc0ad7c4ec832b88342170bdb2db09