### PR TITLE
Add collapsible utility cards to collection view

### DIFF
--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -601,49 +601,82 @@
             </div>
 
             <div class="space-y-6">
-              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <div class="flex items-start justify-between gap-3">
-                  <div>
-                    <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Collection metrics</h3>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 shadow-inner">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                  @click="toggleCard('metrics')"
+                  :aria-expanded="collapsibleCards.metrics"
+                  aria-controls="card-content-metrics"
+                >
+                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Collection metrics</h3>
+                  <span class="text-lg leading-none text-slate-400">
+                    {{ collapsibleCards.metrics ? '−' : '+' }}
+                  </span>
+                </button>
+                <div
+                  v-if="collapsibleCards.metrics"
+                  id="card-content-metrics"
+                  class="space-y-4 border-t border-slate-800/80 px-5 py-4"
+                >
+                  <div class="flex items-start justify-between gap-3">
                     <p class="text-xs text-slate-400">Estimated storage usage returned by the size endpoint.</p>
-                  </div>
-                  <button
-                    type="button"
-                    class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="!selectedCollection || sizeMetrics.loading"
-                    @click="refreshSizeMetrics"
-                  >
-                    {{ sizeMetrics.loading ? 'Refreshing…' : 'Refresh' }}
-                  </button>
-                </div>
-                <p v-if="!selectedCollection" class="text-sm text-slate-400">
-                  Select a collection to inspect its metrics.
-                </p>
-                <p v-else-if="sizeMetrics.loading" class="text-sm text-slate-400">Loading metrics…</p>
-                <p v-else-if="sizeMetrics.error" class="text-sm text-rose-400">{{ sizeMetrics.error }}</p>
-                <div v-else-if="sizeMetricsEntries.length > 0" class="space-y-3">
-                  <p v-if="sizeMetricsUpdatedLabel" class="text-[11px] uppercase tracking-wide text-slate-500">
-                    Updated at {{ sizeMetricsUpdatedLabel }}
-                  </p>
-                  <dl class="divide-y divide-slate-800 rounded-lg border border-slate-800/70 bg-slate-950/60">
-                    <div
-                      v-for="entry in sizeMetricsEntries"
-                      :key="entry.key"
-                      class="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+                    <button
+                      type="button"
+                      class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="!selectedCollection || sizeMetrics.loading"
+                      @click="refreshSizeMetrics"
                     >
-                      <dt class="text-slate-300">{{ entry.label }}</dt>
-                      <dd class="font-mono text-slate-100" :title="entry.tooltip">{{ entry.value }}</dd>
-                    </div>
-                  </dl>
+                      {{ sizeMetrics.loading ? 'Refreshing…' : 'Refresh' }}
+                    </button>
+                  </div>
+                  <p v-if="!selectedCollection" class="text-sm text-slate-400">
+                    Select a collection to inspect its metrics.
+                  </p>
+                  <p v-else-if="sizeMetrics.loading" class="text-sm text-slate-400">Loading metrics…</p>
+                  <p v-else-if="sizeMetrics.error" class="text-sm text-rose-400">{{ sizeMetrics.error }}</p>
+                  <div v-else-if="sizeMetricsEntries.length > 0" class="space-y-3">
+                    <p v-if="sizeMetricsUpdatedLabel" class="text-[11px] uppercase tracking-wide text-slate-500">
+                      Updated at {{ sizeMetricsUpdatedLabel }}
+                    </p>
+                    <dl class="divide-y divide-slate-800 rounded-lg border border-slate-800/70 bg-slate-950/60">
+                      <div
+                        v-for="entry in sizeMetricsEntries"
+                        :key="entry.key"
+                        class="flex items-center justify-between gap-3 px-3 py-2 text-sm"
+                      >
+                        <dt class="text-slate-300">{{ entry.label }}</dt>
+                        <dd class="font-mono text-slate-100" :title="entry.tooltip">{{ entry.value }}</dd>
+                      </div>
+                    </dl>
+                  </div>
+                  <p v-else-if="sizeMetrics.data" class="text-sm text-slate-400">No metrics reported for this collection.</p>
+                  <p v-else class="text-sm text-slate-400">Metrics will appear after refreshing.</p>
                 </div>
-                <p v-else-if="sizeMetrics.data" class="text-sm text-slate-400">No metrics reported for this collection.</p>
-                <p v-else class="text-sm text-slate-400">Metrics will appear after refreshing.</p>
               </div>
 
-              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <div class="space-y-2">
-                  <div class="flex items-center gap-2">
-                    <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Collection defaults</h3>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 shadow-inner">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                  @click="toggleCard('defaults')"
+                  :aria-expanded="collapsibleCards.defaults"
+                  aria-controls="card-content-defaults"
+                >
+                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Collection defaults</h3>
+                  <span class="text-lg leading-none text-slate-400">
+                    {{ collapsibleCards.defaults ? '−' : '+' }}
+                  </span>
+                </button>
+                <div
+                  v-if="collapsibleCards.defaults"
+                  id="card-content-defaults"
+                  class="space-y-4 border-t border-slate-800/80 px-5 py-4"
+                >
+                  <div class="flex items-start justify-between gap-2">
+                    <p class="text-xs text-slate-400">
+                      Documents missing fields will receive these values when inserted.
+                    </p>
                     <button
                       type="button"
                       class="text-base leading-none text-slate-400 transition hover:text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500/70 rounded-full"
@@ -654,9 +687,6 @@
                       <span aria-hidden="true">🛈</span>
                     </button>
                   </div>
-                  <p class="text-xs text-slate-400">
-                    Documents missing fields will receive these values when inserted.
-                  </p>
                   <div
                     v-if="defaultsHelpOpen"
                     class="space-y-2 rounded-lg border border-slate-800/70 bg-slate-950/60 p-3 text-[11px] text-slate-400"
@@ -677,256 +707,305 @@
                       </li>
                     </ul>
                   </div>
+                  <textarea
+                    v-model="defaultsForm.draft"
+                    rows="8"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    placeholder='{"verified": false}'
+                    :disabled="!selectedCollection"
+                  ></textarea>
+                  <div class="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="!selectedCollection || defaultsForm.saving || defaultsForm.draft === defaultsForm.original"
+                      @click="resetDefaultsForm"
+                    >
+                      Reset changes
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded-md bg-sky-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="!selectedCollection || defaultsForm.saving"
+                      @click="saveDefaults"
+                    >
+                      {{ defaultsForm.saving ? 'Saving…' : 'Save defaults' }}
+                    </button>
+                  </div>
+                  <p v-if="defaultsForm.error" class="text-sm text-rose-400">{{ defaultsForm.error }}</p>
+                  <p v-else-if="defaultsForm.success" class="text-sm text-emerald-400">{{ defaultsForm.success }}</p>
                 </div>
-                <textarea
-                  v-model="defaultsForm.draft"
-                  rows="8"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                  placeholder='{"verified": false}'
-                  :disabled="!selectedCollection"
-                ></textarea>
-                <div class="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="!selectedCollection || defaultsForm.saving || defaultsForm.draft === defaultsForm.original"
-                    @click="resetDefaultsForm"
-                  >
-                    Reset changes
-                  </button>
-                  <button
-                    type="button"
-                    class="rounded-md bg-sky-600 px-3 py-2 text-xs font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="!selectedCollection || defaultsForm.saving"
-                    @click="saveDefaults"
-                  >
-                    {{ defaultsForm.saving ? 'Saving…' : 'Save defaults' }}
-                  </button>
-                </div>
-                <p v-if="defaultsForm.error" class="text-sm text-rose-400">{{ defaultsForm.error }}</p>
-                <p v-else-if="defaultsForm.success" class="text-sm text-emerald-400">{{ defaultsForm.success }}</p>
               </div>
 
-              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Insert document</h3>
-                <textarea
-                  v-model="insertForm.payload"
-                  rows="8"
-                  class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
-                  placeholder='{"name": "Ada"}'
-                ></textarea>
-                <div class="flex justify-end">
-                  <button
-                    type="button"
-                    class="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-500 transition"
-                    @click="insertDocument"
-                  >
-                    Insert
-                  </button>
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 shadow-inner">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                  @click="toggleCard('insert')"
+                  :aria-expanded="collapsibleCards.insert"
+                  aria-controls="card-content-insert"
+                >
+                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Insert document</h3>
+                  <span class="text-lg leading-none text-slate-400">
+                    {{ collapsibleCards.insert ? '−' : '+' }}
+                  </span>
+                </button>
+                <div
+                  v-if="collapsibleCards.insert"
+                  id="card-content-insert"
+                  class="space-y-4 border-t border-slate-800/80 px-5 py-4"
+                >
+                  <textarea
+                    v-model="insertForm.payload"
+                    rows="8"
+                    class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm font-mono text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                    placeholder='{"name": "Ada"}'
+                  ></textarea>
+                  <div class="flex justify-end">
+                    <button
+                      type="button"
+                      class="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white hover:bg-sky-500 transition"
+                      @click="insertDocument"
+                    >
+                      Insert
+                    </button>
+                  </div>
+                  <p v-if="insertForm.error" class="text-sm text-rose-400">{{ insertForm.error }}</p>
+                  <p v-else-if="insertForm.success" class="text-sm text-emerald-400">{{ insertForm.success }}</p>
                 </div>
-                <p v-if="insertForm.error" class="text-sm text-rose-400">{{ insertForm.error }}</p>
-                <p v-else-if="insertForm.success" class="text-sm text-emerald-400">{{ insertForm.success }}</p>
               </div>
 
-              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <div class="space-y-2">
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 shadow-inner">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                  @click="toggleCard('importCsv')"
+                  :aria-expanded="collapsibleCards.importCsv"
+                  aria-controls="card-content-import"
+                >
                   <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Import CSV</h3>
+                  <span class="text-lg leading-none text-slate-400">
+                    {{ collapsibleCards.importCsv ? '−' : '+' }}
+                  </span>
+                </button>
+                <div
+                  v-if="collapsibleCards.importCsv"
+                  id="card-content-import"
+                  class="space-y-4 border-t border-slate-800/80 px-5 py-4"
+                >
                   <p class="text-xs text-slate-400">
                     Upload a CSV file to insert multiple documents at once. The first row should contain the field names.
                   </p>
-                </div>
-                <div class="grid gap-3 md:grid-cols-2">
-                  <div class="md:col-span-2">
-                    <label for="csv-file" class="block text-xs uppercase tracking-wide text-slate-400">CSV file</label>
-                    <input
-                      :key="csvImportForm.inputKey"
-                      id="csv-file"
-                      type="file"
-                      accept=".csv,text/csv"
-                      class="mt-1 block w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 file:mr-4 file:rounded-md file:border-0 file:bg-slate-800 file:px-4 file:py-2 file:text-sm file:font-medium file:text-slate-100 hover:file:bg-slate-700"
-                      @change="onCsvFileChange"
-                    >
+                  <div class="grid gap-3 md:grid-cols-2">
+                    <div class="md:col-span-2">
+                      <label for="csv-file" class="block text-xs uppercase tracking-wide text-slate-400">CSV file</label>
+                      <input
+                        :key="csvImportForm.inputKey"
+                        id="csv-file"
+                        type="file"
+                        accept=".csv,text/csv"
+                        class="mt-1 block w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500 file:mr-4 file:rounded-md file:border-0 file:bg-slate-800 file:px-4 file:py-2 file:text-sm file:font-medium file:text-slate-100 hover:file:bg-slate-700"
+                        @change="onCsvFileChange"
+                      >
+                    </div>
+                    <div>
+                      <label for="csv-delimiter" class="block text-xs uppercase tracking-wide text-slate-400">Delimiter</label>
+                      <select
+                        id="csv-delimiter"
+                        v-model="csvImportForm.delimiter"
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                      >
+                        <option value=",">Comma (,)</option>
+                        <option value=";">Semicolon (;)</option>
+                        <option value="\t">Tab</option>
+                        <option value="|">Pipe (|)</option>
+                      </select>
+                    </div>
+                    <div>
+                      <label for="csv-trim" class="block text-xs uppercase tracking-wide text-slate-400">Trim whitespace</label>
+                      <select
+                        id="csv-trim"
+                        v-model="csvImportForm.trimValues"
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                      >
+                        <option :value="true">Yes</option>
+                        <option :value="false">No</option>
+                      </select>
+                    </div>
                   </div>
-                  <div>
-                    <label for="csv-delimiter" class="block text-xs uppercase tracking-wide text-slate-400">Delimiter</label>
-                    <select
-                      id="csv-delimiter"
-                      v-model="csvImportForm.delimiter"
-                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                  <p v-if="csvImportForm.fileName" class="text-xs text-slate-500">Selected file: {{ csvImportForm.fileName }}</p>
+                  <div class="flex justify-end gap-2">
+                    <button
+                      type="button"
+                      class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="csvImportForm.importing"
+                      @click="resetCsvImportForm"
                     >
-                      <option value=",">Comma (,)</option>
-                      <option value=";">Semicolon (;)</option>
-                      <option value="\t">Tab</option>
-                      <option value="|">Pipe (|)</option>
-                    </select>
-                  </div>
-                  <div>
-                    <label for="csv-trim" class="block text-xs uppercase tracking-wide text-slate-400">Trim whitespace</label>
-                    <select
-                      id="csv-trim"
-                      v-model="csvImportForm.trimValues"
-                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm text-slate-200 focus:outline-none focus:ring-2 focus:ring-sky-500"
+                      Clear
+                    </button>
+                    <button
+                      type="button"
+                      class="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
+                      :disabled="!csvImportForm.file || csvImportForm.importing"
+                      @click="importCsv"
                     >
-                      <option :value="true">Yes</option>
-                      <option :value="false">No</option>
-                    </select>
+                      {{ csvImportForm.importing ? 'Importing…' : 'Import CSV' }}
+                    </button>
                   </div>
+                  <p v-if="csvImportForm.error" class="text-sm text-rose-400">{{ csvImportForm.error }}</p>
+                  <p v-else-if="csvImportForm.success" class="text-sm text-emerald-400">{{ csvImportForm.success }}</p>
+                  <p v-else-if="csvImportForm.progress" class="text-sm text-slate-400">{{ csvImportForm.progress }}</p>
                 </div>
-                <p v-if="csvImportForm.fileName" class="text-xs text-slate-500">Selected file: {{ csvImportForm.fileName }}</p>
-                <div class="flex justify-end gap-2">
-                  <button
-                    type="button"
-                    class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 transition hover:bg-slate-800 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="csvImportForm.importing"
-                    @click="resetCsvImportForm"
-                  >
-                    Clear
-                  </button>
-                  <button
-                    type="button"
-                    class="rounded-md bg-sky-600 px-4 py-2 text-sm font-semibold text-white transition hover:bg-sky-500 disabled:cursor-not-allowed disabled:opacity-60"
-                    :disabled="!csvImportForm.file || csvImportForm.importing"
-                    @click="importCsv"
-                  >
-                    {{ csvImportForm.importing ? 'Importing…' : 'Import CSV' }}
-                  </button>
-                </div>
-                <p v-if="csvImportForm.error" class="text-sm text-rose-400">{{ csvImportForm.error }}</p>
-                <p v-else-if="csvImportForm.success" class="text-sm text-emerald-400">{{ csvImportForm.success }}</p>
-                <p v-else-if="csvImportForm.progress" class="text-sm text-slate-400">{{ csvImportForm.progress }}</p>
               </div>
 
-              <div class="rounded-xl border border-slate-800 bg-slate-900/60 p-5 shadow-inner space-y-4">
-                <div class="flex items-center justify-between gap-3">
-                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Indexes</h3>
-                  <button
-                    type="button"
-                    class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
-                    @click="toggleIndexForm"
-                  >
-                    {{ indexForm.open ? 'Cancel' : 'New index' }}
-                  </button>
-                </div>
-                <p v-if="indexMessages.error" class="text-sm text-rose-400">{{ indexMessages.error }}</p>
-                <p v-else-if="indexMessages.success" class="text-sm text-emerald-400">{{ indexMessages.success }}</p>
-                <form
-                  v-if="indexForm.open"
-                  class="space-y-3 rounded-lg border border-slate-800/70 bg-slate-950/60 p-4"
-                  @submit.prevent="createIndex"
+              <div class="rounded-xl border border-slate-800 bg-slate-900/60 shadow-inner">
+                <button
+                  type="button"
+                  class="flex w-full items-center justify-between gap-3 px-5 py-4 text-left"
+                  @click="toggleCard('indexes')"
+                  :aria-expanded="collapsibleCards.indexes"
+                  aria-controls="card-content-indexes"
                 >
-                  <div>
-                    <label for="index-name" class="block text-xs uppercase tracking-wide text-slate-400">Name</label>
-                    <input
-                      id="index-name"
-                      v-model="indexForm.name"
-                      type="text"
-                      required
-                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
-                      placeholder="by_email"
-                    >
-                  </div>
-                  <div>
-                    <label for="index-type" class="block text-xs uppercase tracking-wide text-slate-400">Type</label>
-                    <select
-                      id="index-type"
-                      v-model="indexForm.type"
-                      class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
-                    >
-                      <option value="map">Map</option>
-                      <option value="btree">B-Tree</option>
-                    </select>
-                  </div>
-                  <div v-if="indexForm.type === 'map'" class="space-y-2">
-                    <div>
-                      <label for="index-field" class="block text-xs uppercase tracking-wide text-slate-400">Field</label>
-                      <input
-                        id="index-field"
-                        v-model="indexForm.field"
-                        type="text"
-                        required
-                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
-                        placeholder="email"
-                      >
-                    </div>
-                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
-                      <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
-                      Sparse (ignore documents without the field)
-                    </label>
-                  </div>
-                  <div v-else class="space-y-2">
-                    <div>
-                      <label for="index-fields" class="block text-xs uppercase tracking-wide text-slate-400">Fields</label>
-                      <input
-                        id="index-fields"
-                        v-model="indexForm.fieldsText"
-                        type="text"
-                        required
-                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
-                        placeholder="lastName, firstName"
-                      >
-                      <p class="mt-1 text-[11px] text-slate-500">
-                        Separate fields with commas. Prefix with "-" for descending order.
-                      </p>
-                    </div>
-                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
-                      <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
-                      Sparse (ignore documents missing the fields)
-                    </label>
-                    <label class="inline-flex items-center gap-2 text-xs text-slate-300">
-                      <input type="checkbox" v-model="indexForm.unique" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
-                      Unique (reject duplicate combinations)
-                    </label>
-                  </div>
-                  <div class="flex justify-end gap-2">
+                  <h3 class="text-sm font-semibold text-slate-200 uppercase tracking-wide">Indexes</h3>
+                  <span class="text-lg leading-none text-slate-400">
+                    {{ collapsibleCards.indexes ? '−' : '+' }}
+                  </span>
+                </button>
+                <div
+                  v-if="collapsibleCards.indexes"
+                  id="card-content-indexes"
+                  class="space-y-4 border-t border-slate-800/80 px-5 py-4"
+                >
+                  <div class="flex justify-end">
                     <button
                       type="button"
                       class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
                       @click="toggleIndexForm"
                     >
-                      Cancel
-                    </button>
-                    <button
-                      type="submit"
-                      class="rounded-md bg-sky-600 px-3 py-2 text-xs font-semibold text-white hover:bg-sky-500 transition disabled:cursor-not-allowed disabled:opacity-60"
-                      :disabled="indexForm.submitting"
-                    >
-                      {{ indexForm.submitting ? 'Creating…' : 'Create index' }}
+                      {{ indexForm.open ? 'Cancel' : 'New index' }}
                     </button>
                   </div>
-                </form>
-                <div v-if="indexesLoading" class="text-sm text-slate-400">Loading indexes…</div>
-                <div v-else-if="indexes.length === 0" class="text-sm text-slate-400">This collection has no indexes yet.</div>
-                <ul v-else class="space-y-3 text-sm text-slate-300">
-                  <li
-                    v-for="index in indexes"
-                    :key="index.name"
-                    class="rounded-lg border border-slate-800 bg-slate-950 p-3"
+                  <p v-if="indexMessages.error" class="text-sm text-rose-400">{{ indexMessages.error }}</p>
+                  <p v-else-if="indexMessages.success" class="text-sm text-emerald-400">{{ indexMessages.success }}</p>
+                  <form
+                    v-if="indexForm.open"
+                    class="space-y-3 rounded-lg border border-slate-800/70 bg-slate-950/60 p-4"
+                    @submit.prevent="createIndex"
                   >
-                    <div class="flex items-start justify-between gap-3">
-                      <div class="space-y-2">
-                        <div class="flex items-center gap-2 text-slate-200">
-                          <span class="font-semibold">{{ index.name }}</span>
-                          <span class="rounded-full border border-slate-700/80 bg-slate-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-slate-400">
-                            {{ index.type === 'btree' ? 'B-Tree' : 'Map' }}
-                          </span>
-                        </div>
-                        <p v-if="index.type === 'map'" class="text-xs text-slate-400">Field: {{ index.field }}</p>
-                        <p v-else-if="index.type === 'btree'" class="text-xs text-slate-400">Fields: {{ Array.isArray(index.fields) ? index.fields.join(', ') : '' }}</p>
-                        <div class="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide text-slate-400">
-                          <span v-if="index.unique" class="rounded bg-slate-800 px-2 py-0.5 text-emerald-300/90">Unique</span>
-                          <span v-if="index.sparse" class="rounded bg-slate-800 px-2 py-0.5 text-slate-200/80">Sparse</span>
-                        </div>
+                    <div>
+                      <label for="index-name" class="block text-xs uppercase tracking-wide text-slate-400">Name</label>
+                      <input
+                        id="index-name"
+                        v-model="indexForm.name"
+                        type="text"
+                        required
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                        placeholder="by_email"
+                      >
+                    </div>
+                    <div>
+                      <label for="index-type" class="block text-xs uppercase tracking-wide text-slate-400">Type</label>
+                      <select
+                        id="index-type"
+                        v-model="indexForm.type"
+                        class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                      >
+                        <option value="map">Map</option>
+                        <option value="btree">B-Tree</option>
+                      </select>
+                    </div>
+                    <div v-if="indexForm.type === 'map'" class="space-y-2">
+                      <div>
+                        <label for="index-field" class="block text-xs uppercase tracking-wide text-slate-400">Field</label>
+                        <input
+                          id="index-field"
+                          v-model="indexForm.field"
+                          type="text"
+                          required
+                          class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                          placeholder="email"
+                        >
                       </div>
+                      <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                        <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                        Sparse (ignore documents without the field)
+                      </label>
+                    </div>
+                    <div v-else class="space-y-2">
+                      <div>
+                        <label for="index-fields" class="block text-xs uppercase tracking-wide text-slate-400">Fields</label>
+                        <input
+                          id="index-fields"
+                          v-model="indexForm.fieldsText"
+                          type="text"
+                          required
+                          class="mt-1 w-full rounded-md border border-slate-700 bg-slate-950 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-sky-500"
+                          placeholder="lastName, firstName"
+                        >
+                        <p class="mt-1 text-[11px] text-slate-500">
+                          Separate fields with commas. Prefix with "-" for descending order.
+                        </p>
+                      </div>
+                      <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                        <input type="checkbox" v-model="indexForm.sparse" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                        Sparse (ignore documents missing the fields)
+                      </label>
+                      <label class="inline-flex items-center gap-2 text-xs text-slate-300">
+                        <input type="checkbox" v-model="indexForm.unique" class="h-4 w-4 rounded border-slate-700 bg-slate-900">
+                        Unique (reject duplicate combinations)
+                      </label>
+                    </div>
+                    <div class="flex justify-end gap-2">
                       <button
                         type="button"
-                        class="rounded-md border border-rose-500/40 bg-rose-600/20 px-2 py-1 text-xs font-semibold text-rose-200 hover:bg-rose-600/30 transition"
-                        @click="removeIndex(index)"
+                        class="rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
+                        @click="toggleIndexForm"
                       >
-                        Delete
+                        Cancel
+                      </button>
+                      <button
+                        type="submit"
+                        class="rounded-md bg-sky-600 px-3 py-2 text-xs font-semibold text-white hover:bg-sky-500 transition disabled:cursor-not-allowed disabled:opacity-60"
+                        :disabled="indexForm.submitting"
+                      >
+                        {{ indexForm.submitting ? 'Creating…' : 'Create index' }}
                       </button>
                     </div>
-                  </li>
-                </ul>
+                  </form>
+                  <div v-if="indexesLoading" class="text-sm text-slate-400">Loading indexes…</div>
+                  <div v-else-if="indexes.length === 0" class="text-sm text-slate-400">This collection has no indexes yet.</div>
+                  <ul v-else class="space-y-3 text-sm text-slate-300">
+                    <li
+                      v-for="index in indexes"
+                      :key="index.name"
+                      class="rounded-lg border border-slate-800 bg-slate-950 p-3"
+                    >
+                      <div class="flex items-start justify-between gap-3">
+                        <div class="space-y-2">
+                          <div class="flex items-center gap-2 text-slate-200">
+                            <span class="font-semibold">{{ index.name }}</span>
+                            <span class="rounded-full border border-slate-700/80 bg-slate-900 px-2 py-0.5 text-[11px] uppercase tracking-wide text-slate-400">
+                              {{ index.type === 'btree' ? 'B-Tree' : 'Map' }}
+                            </span>
+                          </div>
+                          <p v-if="index.type === 'map'" class="text-xs text-slate-400">Field: {{ index.field }}</p>
+                          <p v-else-if="index.type === 'btree'" class="text-xs text-slate-400">Fields: {{ Array.isArray(index.fields) ? index.fields.join(', ') : '' }}</p>
+                          <div class="flex flex-wrap gap-2 text-[11px] uppercase tracking-wide text-slate-400">
+                            <span v-if="index.unique" class="rounded bg-slate-800 px-2 py-0.5 text-emerald-300/90">Unique</span>
+                            <span v-if="index.sparse" class="rounded bg-slate-800 px-2 py-0.5 text-slate-200/80">Sparse</span>
+                          </div>
+                        </div>
+                        <button
+                          type="button"
+                          class="rounded-md border border-rose-500/40 bg-rose-600/20 px-2 py-1 text-xs font-semibold text-rose-200 hover:bg-rose-600/30 transition"
+                          @click="removeIndex(index)"
+                        >
+                          Delete
+                        </button>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
               </div>
 
             </div>
@@ -1073,6 +1152,13 @@
             saving: false,
           });
           const defaultsHelpOpen = ref(false);
+          const collapsibleCards = reactive({
+            metrics: false,
+            defaults: false,
+            insert: false,
+            importCsv: false,
+            indexes: false,
+          });
           const createForm = reactive({ open: false, name: '', error: '' });
           const indexForm = reactive({
             open: false,
@@ -1839,6 +1925,16 @@
           const toggleCreateForm = () => {
             createForm.open = !createForm.open;
             createForm.error = '';
+          };
+
+          const toggleCard = (name) => {
+            if (!Object.prototype.hasOwnProperty.call(collapsibleCards, name)) {
+              return;
+            }
+            collapsibleCards[name] = !collapsibleCards[name];
+            if (!collapsibleCards[name] && name === 'defaults') {
+              defaultsHelpOpen.value = false;
+            }
           };
 
           const resetIndexForm = () => {
@@ -3065,6 +3161,7 @@
             csvImportForm,
             defaultsForm,
             defaultsHelpOpen,
+            collapsibleCards,
             createForm,
             connectionStatus,
             activityLog,
@@ -3091,6 +3188,7 @@
             prettyTotal,
             isSelected,
             toggleCreateForm,
+            toggleCard,
             toggleIndexForm,
             selectCollection,
             runQuery,


### PR DESCRIPTION
## Summary
- add collapsible toggles for the right-side utility cards in the collection view
- store the card open state in Vue and provide a helper to toggle sections
- adapt the indexes card layout to render inside the collapsible container

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc25910b94832b8e9922ce60b973ae