### PR TITLE
Add request details to activity history modal

### DIFF
--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -1070,7 +1070,9 @@
               {{ activityStatusLabel(selectedActivityEntry.status) }}
             </span>
           </div>
-          <p class="mt-3 break-all text-xs text-slate-300">{{ selectedActivityEntry.url }}</p>
+          <p class="mt-3 break-all text-xs text-slate-300">
+            {{ selectedActivityEntry.request?.url || selectedActivityEntry.url }}
+          </p>
           <p v-if="selectedActivityEntry.target" class="mt-2 text-[11px] uppercase tracking-wide text-slate-500">
             Target: {{ selectedActivityEntry.target }}
           </p>
@@ -1082,7 +1084,39 @@
             <span>Started {{ formatActivityTime(selectedActivityEntry.startedAt) }}</span>
             <span v-if="selectedActivityEntry.durationMs !== null">Duration {{ formatDuration(selectedActivityEntry.durationMs) }}</span>
           </div>
-          <div class="mt-4 flex flex-wrap justify-end gap-2">
+          <div
+            v-if="selectedActivityEntry.request"
+            class="mt-4 space-y-4 border-t border-slate-800 pt-4 text-xs text-slate-300"
+          >
+            <div>
+              <p class="text-[11px] uppercase tracking-wide text-slate-500">Request URL</p>
+              <p class="mt-1 break-all text-slate-200">
+                {{ selectedActivityEntry.request.url || selectedActivityEntry.url }}
+              </p>
+            </div>
+            <div v-if="selectedActivityEntry.request.headers.length">
+              <p class="text-[11px] uppercase tracking-wide text-slate-500">Headers</p>
+              <ul class="mt-1 space-y-1">
+                <li
+                  v-for="header in selectedActivityEntry.request.headers"
+                  :key="`${header.name}:${header.value}`"
+                  class="break-all text-slate-300"
+                >
+                  <span class="text-slate-400">{{ header.name }}:</span>
+                  {{ header.value }}
+                </li>
+              </ul>
+            </div>
+            <div v-if="selectedActivityEntry.request.bodyPretty">
+              <p class="text-[11px] uppercase tracking-wide text-slate-500">Body</p>
+              <pre class="mt-1 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-slate-900/80 p-3 text-xs text-slate-200">{{ selectedActivityEntry.request.bodyPretty }}</pre>
+            </div>
+            <div v-if="selectedActivityEntry.request.curlCommand">
+              <p class="text-[11px] uppercase tracking-wide text-slate-500">cURL</p>
+              <pre class="mt-1 max-h-56 overflow-auto whitespace-pre-wrap break-words rounded-md bg-slate-900/80 p-3 text-xs text-slate-200">{{ selectedActivityEntry.request.curlCommand }}</pre>
+            </div>
+          </div>
+          <div class="mt-5 flex flex-wrap justify-end gap-2">
             <button
               type="button"
               class="rounded-md border border-slate-700 bg-slate-900 px-3 py-1.5 text-xs font-semibold text-slate-200 hover:bg-slate-800 transition"
@@ -1206,6 +1240,101 @@
           });
           const numberFormatter = new Intl.NumberFormat('en-US');
 
+          const shellQuote = (value) => `'${String(value).replace(/'/g, "'\\''")}'`;
+
+          const resolveActivityUrl = (rawUrl) => {
+            if (!rawUrl) return '';
+            try {
+              return new URL(rawUrl, window.location.origin).href;
+            } catch (error) {
+              return String(rawUrl);
+            }
+          };
+
+          const buildCurlCommand = ({ method, url, headers, bodyText }) => {
+            if (!url) return '';
+            const segments = ['curl'];
+            const normalizedMethod = method ? String(method).toUpperCase() : 'GET';
+            if (normalizedMethod !== 'GET') {
+              segments.push(`-X ${normalizedMethod}`);
+            }
+            headers.forEach(({ name, value }) => {
+              segments.push(`-H ${shellQuote(`${name}: ${value}`)}`);
+            });
+            if (bodyText) {
+              segments.push(`--data ${shellQuote(bodyText)}`);
+            }
+            segments.push(shellQuote(url));
+            return segments.join(' ');
+          };
+
+          const normalizeActivityRequest = (input = {}) => {
+            if (!input || typeof input !== 'object') return null;
+            const method = typeof input.method === 'string' && input.method
+              ? input.method.toUpperCase()
+              : '';
+            const originalUrl = typeof input.url === 'string' ? input.url : '';
+            const resolvedUrl = resolveActivityUrl(originalUrl || input.url || '');
+            const headers = [];
+            if (input.headers && typeof input.headers === 'object') {
+              Object.entries(input.headers).forEach(([name, value]) => {
+                if (value === undefined || value === null) return;
+                headers.push({ name: String(name), value: String(value) });
+              });
+            }
+            let bodySource;
+            if (Object.prototype.hasOwnProperty.call(input, 'body')) {
+              bodySource = input.body;
+            } else if (Object.prototype.hasOwnProperty.call(input, 'data')) {
+              bodySource = input.data;
+            }
+            let bodyText = '';
+            let bodyPretty = '';
+            if (bodySource !== undefined && bodySource !== null) {
+              if (typeof bodySource === 'string') {
+                bodyText = bodySource;
+                bodyPretty = bodySource;
+              } else {
+                try {
+                  bodyText = JSON.stringify(bodySource);
+                  bodyPretty = JSON.stringify(bodySource, null, 2);
+                } catch (error) {
+                  const fallback = String(bodySource);
+                  bodyText = fallback;
+                  bodyPretty = fallback;
+                }
+              }
+            }
+            if (bodyText) {
+              const hasContentType = headers.some((header) => header.name.toLowerCase() === 'content-type');
+              if (!hasContentType) {
+                const trimmed = bodyText.trim();
+                if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+                  headers.push({ name: 'Content-Type', value: 'application/json' });
+                }
+              }
+            }
+            headers.sort((a, b) => a.name.localeCompare(b.name));
+            const normalizedMethod = method || (bodyText ? 'POST' : 'GET');
+            const curlCommand = resolvedUrl
+              ? buildCurlCommand({
+                  method: normalizedMethod,
+                  url: resolvedUrl,
+                  headers,
+                  bodyText,
+                })
+              : '';
+            return {
+              method: normalizedMethod,
+              url: resolvedUrl,
+              originalUrl,
+              headers,
+              bodyText,
+              bodyPretty,
+              curlCommand,
+            };
+          };
+
           const toNonNegativeInteger = (value, fallback = 0) => {
             const num = Number(value);
             if (!Number.isFinite(num)) return fallback;
@@ -1213,12 +1342,17 @@
             return Math.max(0, Math.floor(num));
           };
 
-          const createActivityEntry = ({ label, method, url, target }) => {
+          const createActivityEntry = ({ label, method, url, target, request }) => {
+            const normalizedLabel = typeof label === 'string' ? label : '';
+            const normalizedMethod = typeof method === 'string' && method
+              ? method.toUpperCase()
+              : 'REQUEST';
+            const normalizedUrl = typeof url === 'string' ? url : '';
             const entry = {
               id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-              label,
-              method,
-              url,
+              label: normalizedLabel,
+              method: normalizedMethod,
+              url: normalizedUrl,
               target: target || '',
               status: 'pending',
               statusCode: null,
@@ -1226,7 +1360,30 @@
               startedAt: new Date(),
               finishedAt: null,
               durationMs: null,
+              request: null,
             };
+            if (request) {
+              const normalizedRequest = normalizeActivityRequest({
+                method: request.method ?? method,
+                url: request.url ?? url,
+                headers: request.headers,
+                data: Object.prototype.hasOwnProperty.call(request, 'data')
+                  ? request.data
+                  : Object.prototype.hasOwnProperty.call(request, 'body')
+                    ? request.body
+                    : request.payload,
+                body: request.body,
+              });
+              if (normalizedRequest) {
+                entry.request = normalizedRequest;
+                if (normalizedRequest.method) {
+                  entry.method = normalizedRequest.method;
+                }
+                if (!entry.url) {
+                  entry.url = normalizedRequest.originalUrl || normalizedRequest.url || '';
+                }
+              }
+            }
             activityLog.value.unshift(entry);
             if (activityLog.value.length > MAX_ACTIVITY_LOG_ENTRIES) {
               activityLog.value.splice(MAX_ACTIVITY_LOG_ENTRIES);
@@ -1545,6 +1702,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: ndjsonPayload,
+              },
             });
             try {
               const resp = await axios.post(url, ndjsonPayload, {
@@ -1663,10 +1826,9 @@
 
           const activityMarkerTitle = (entry) => {
             if (!entry) return 'Request';
-            const segments = [];
-            if (entry.method) segments.push(String(entry.method).toUpperCase());
-            if (entry.label) segments.push(entry.label);
-            return segments.join(' · ') || 'Request';
+            if (entry.label) return entry.label;
+            if (entry.method) return String(entry.method).toUpperCase();
+            return 'Request';
           };
 
           const clamp = (value, min, max) => Math.min(Math.max(value, min), max);
@@ -2155,18 +2317,25 @@
             }
             state.saving = true;
             const url = `/v1/collections/${encodeURIComponent(selectedCollection.value.name)}:patch`;
+            const requestPayload = {
+              filter: { id: row.id },
+              patch: preparedPatch,
+              limit: 1,
+            };
             const entry = createActivityEntry({
               label: `Edit document ${id}`,
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: requestPayload,
+              },
             });
             try {
-              const resp = await axios.post(url, {
-                filter: { id: row.id },
-                patch: preparedPatch,
-                limit: 1,
-              });
+              const resp = await axios.post(url, requestPayload);
               markConnectionOnline();
               completeActivityEntry(entry, {
                 detail: `Document ${id} updated successfully.`,
@@ -2230,6 +2399,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: payload,
+              },
             });
             try {
               const resp = await axios.post(url, payload);
@@ -2265,6 +2440,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: { name: index.name },
+              },
             });
             try {
               const resp = await axios.post(url, { name: index.name });
@@ -2431,6 +2612,10 @@
               label: 'List collections',
               method: 'GET',
               url: '/v1/collections',
+              request: {
+                method: 'GET',
+                url: '/v1/collections',
+              },
             });
             try {
               const resp = await axios.get('/v1/collections');
@@ -2466,6 +2651,10 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+              },
             });
             try {
               const resp = await axios.post(url);
@@ -2504,6 +2693,10 @@
               method: 'POST',
               url,
               target: collectionName,
+              request: {
+                method: 'POST',
+                url,
+              },
             });
             try {
               const resp = await axios.post(url);
@@ -2638,6 +2831,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: payload,
+              },
             });
             try {
               const resp = await axios({
@@ -2747,16 +2946,27 @@
             }
 
             const url = `/v1/collections/${encodeURIComponent(collectionName)}:find`;
+            const baseExportPayload = JSON.parse(JSON.stringify(lastQueryParameters.payload || {}));
             const entry = createActivityEntry({
               label: 'Export all results (JSONL)',
               method: 'POST',
               url,
               target: collectionName,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: {
+                  ...baseExportPayload,
+                  skip: 0,
+                  limit: EXPORT_BATCH_SIZE,
+                },
+              },
             });
             exportState.progress = 'Preparing export for all matching documents…';
 
             try {
-              const template = JSON.parse(JSON.stringify(lastQueryParameters.payload || {}));
+              const template = JSON.parse(JSON.stringify(baseExportPayload));
               const chunks = [];
               let totalExported = 0;
               let batches = 0;
@@ -2900,17 +3110,24 @@
             const ok = window.confirm(`Delete the document with id ${id}?`);
             if (!ok) return;
             const url = `/v1/collections/${encodeURIComponent(selectedCollection.value.name)}:remove`;
+            const requestPayload = {
+              filter: { id: row.id },
+              limit: 1,
+            };
             const entry = createActivityEntry({
               label: `Delete document ${id}`,
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: requestPayload,
+              },
             });
             try {
-              const resp = await axios.post(url, {
-                filter: { id: row.id },
-                limit: 1,
-              });
+              const resp = await axios.post(url, requestPayload);
               markConnectionOnline();
               completeActivityEntry(entry, {
                 detail: `Deleted document with id ${id}.`,
@@ -2955,6 +3172,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: parsed,
+              },
             });
             try {
               const resp = await axios.post(url, parsed);
@@ -3001,6 +3224,12 @@
               method: 'POST',
               url,
               target: selectedCollection.value.name,
+              request: {
+                method: 'POST',
+                url,
+                headers: { 'Content-Type': 'application/json' },
+                data: payload,
+              },
             });
             try {
               const resp = await axios.post(url, payload);
@@ -3032,6 +3261,12 @@
               method: 'POST',
               url: '/v1/collections',
               target: name,
+              request: {
+                method: 'POST',
+                url: '/v1/collections',
+                headers: { 'Content-Type': 'application/json' },
+                data: { name },
+              },
             });
             try {
               const resp = await axios.post('/v1/collections', { name });
@@ -3063,6 +3298,10 @@
               method: 'POST',
               url,
               target: name,
+              request: {
+                method: 'POST',
+                url,
+              },
             });
             try {
               const resp = await axios.post(url);


### PR DESCRIPTION
## Summary
- display detailed request metadata, including generated cURL commands, when opening an activity entry
- persist normalized request information for history items so hover tooltips show each operation name

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc4812984c832b9ed373b5faed6251