### PR TITLE
Limit activity history to 15 entries

### DIFF
--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -1181,7 +1181,7 @@
             checkedAt: null,
             isChecking: false,
           });
-          const MAX_ACTIVITY_LOG_ENTRIES = 50;
+          const MAX_ACTIVITY_LOG_ENTRIES = 15;
           const EXPORT_BATCH_SIZE = 1000;
           const MAX_EXPORT_BATCHES = 10000;
           const activityLog = ref([]);


### PR DESCRIPTION
## Summary
- reduce the activity log history cap to 15 entries so only the most recent requests are kept

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc4fb14260832baccac0f94697657b