### PR TITLE
Add Go, Python, and PHP request formats to Activity modal

### DIFF
--- a/statics/www/index.html
+++ b/statics/www/index.html
@@ -2061,11 +2061,209 @@
 				return lines.join(' \\\n');
 			};
 
-			const activityRequestTabDefinitions = [
-				{ id: 'http', label: 'HTTP', builder: buildHttpRequest },
-				{ id: 'javascript', label: 'JavaScript', builder: buildJavascriptRequest },
-				{ id: 'curl', label: 'cURL', builder: buildCurlCommand },
-			];
+                        const buildGoRequest = (entry) => {
+                                if (!entry?.request) return '';
+                                const method = (entry.request.method || '').toUpperCase() || 'GET';
+                                const rawUrl = entry.request.url || '';
+                                if (!rawUrl) return '';
+                                let absoluteUrl = rawUrl;
+                                try {
+                                        absoluteUrl = new URL(rawUrl, window.location.origin).toString();
+                                } catch (error) {
+                                        absoluteUrl = rawUrl;
+                                }
+
+                                const headers = activityRequestHeaders(entry);
+                                const body = entry.request.body;
+
+                                const goImports = new Set(['"fmt"', '"io"', '"log"', '"net/http"']);
+                                let bodyDeclaration = '';
+                                let bodyReference = 'nil';
+
+                                if (body !== undefined && body !== null && body !== '') {
+                                        goImports.add('"strings"');
+                                        let bodyString = '';
+                                        if (typeof body === 'string') {
+                                                bodyString = body;
+                                        } else {
+                                                try {
+                                                        bodyString = JSON.stringify(body, null, 2);
+                                                } catch (error) {
+                                                        bodyString = String(body);
+                                                }
+                                        }
+                                        bodyDeclaration = `\tpayload := strings.NewReader(${JSON.stringify(bodyString)})`;
+                                        bodyReference = 'payload';
+                                }
+
+                                const lines = ['package main', '', 'import ('];
+                                Array.from(goImports)
+                                        .sort()
+                                        .forEach((imp) => {
+                                                lines.push(`\t${imp}`);
+                                        });
+                                lines.push(')', '', 'func main() {', '\tclient := &http.Client{}');
+                                if (bodyDeclaration) {
+                                        lines.push(bodyDeclaration);
+                                }
+                                lines.push(
+                                        `\treq, err := http.NewRequest(${JSON.stringify(method)}, ${JSON.stringify(absoluteUrl)}, ${bodyReference})`
+                                );
+                                lines.push('\tif err != nil {', '\t\tlog.Fatal(err)', '\t}');
+                                if (headers.length > 0) {
+                                        lines.push('');
+                                        headers.forEach(({ key, value }) => {
+                                                lines.push(`\treq.Header.Set(${JSON.stringify(key)}, ${JSON.stringify(value)})`);
+                                        });
+                                }
+                                lines.push(
+                                        '',
+                                        '\tresp, err := client.Do(req)',
+                                        '\tif err != nil {',
+                                        '\t\tlog.Fatal(err)',
+                                        '\t}',
+                                        '\tdefer resp.Body.Close()',
+                                        '',
+                                        '\tbody, err := io.ReadAll(resp.Body)',
+                                        '\tif err != nil {',
+                                        '\t\tlog.Fatal(err)',
+                                        '\t}',
+                                        '\tfmt.Println(string(body))',
+                                        '}'
+                                );
+
+                                return lines.join('\n');
+                        };
+
+                        const buildPythonRequest = (entry) => {
+                                if (!entry?.request) return '';
+                                const method = (entry.request.method || '').toUpperCase() || 'GET';
+                                const rawUrl = entry.request.url || '';
+                                if (!rawUrl) return '';
+                                let absoluteUrl = rawUrl;
+                                try {
+                                        absoluteUrl = new URL(rawUrl, window.location.origin).toString();
+                                } catch (error) {
+                                        absoluteUrl = rawUrl;
+                                }
+
+                                const headers = activityRequestHeaders(entry);
+                                const body = entry.request.body;
+
+                                const lines = ['import requests'];
+                                let payloadArgument = '';
+                                if (body !== undefined && body !== null && body !== '') {
+                                        if (typeof body === 'string') {
+                                                lines.push('', `payload = ${JSON.stringify(body)}`);
+                                                payloadArgument = 'data=payload';
+                                        } else {
+                                                let serialized = '';
+                                                try {
+                                                        serialized = JSON.stringify(body, null, 2);
+                                                } catch (error) {
+                                                        serialized = JSON.stringify(String(body));
+                                                }
+                                                lines.unshift('import json');
+                                                lines.push('');
+                                                lines.push('payload = json.loads("""');
+                                                serialized.split('\n').forEach((line) => {
+                                                        lines.push(line);
+                                                });
+                                                lines.push('""")');
+                                                payloadArgument = 'json=payload';
+                                        }
+                                }
+
+                                lines.push('', `url = ${JSON.stringify(absoluteUrl)}`);
+
+                                if (headers.length > 0) {
+                                        lines.push('headers = {');
+                                        headers.forEach(({ key, value }) => {
+                                                lines.push(`    ${JSON.stringify(key)}: ${JSON.stringify(value)},`);
+                                        });
+                                        const lastIndex = lines.length - 1;
+                                        lines[lastIndex] = lines[lastIndex].replace(/,$/, '');
+                                        lines.push('}');
+                                }
+
+                                const requestArgs = [`${JSON.stringify(method)}`, 'url'];
+                                if (headers.length > 0) {
+                                        requestArgs.push('headers=headers');
+                                }
+                                if (payloadArgument) {
+                                        requestArgs.push(payloadArgument);
+                                }
+                                lines.push('', `response = requests.request(${requestArgs.join(', ')})`);
+                                lines.push('print(response.text)');
+
+                                return lines.join('\n');
+                        };
+
+                        const buildPhpRequest = (entry) => {
+                                if (!entry?.request) return '';
+                                const method = (entry.request.method || '').toUpperCase() || 'GET';
+                                const rawUrl = entry.request.url || '';
+                                if (!rawUrl) return '';
+                                let absoluteUrl = rawUrl;
+                                try {
+                                        absoluteUrl = new URL(rawUrl, window.location.origin).toString();
+                                } catch (error) {
+                                        absoluteUrl = rawUrl;
+                                }
+
+                                const headers = activityRequestHeaders(entry);
+                                const body = entry.request.body;
+
+                                const lines = ['<?php', '', '$curl = curl_init();', '', 'curl_setopt_array($curl, ['];
+                                lines.push(`    CURLOPT_URL => ${JSON.stringify(absoluteUrl)},`);
+                                lines.push('    CURLOPT_RETURNTRANSFER => true,');
+                                lines.push(`    CURLOPT_CUSTOMREQUEST => ${JSON.stringify(method)},`);
+
+                                if (headers.length > 0) {
+                                        lines.push('    CURLOPT_HTTPHEADER => [');
+                                        headers.forEach(({ key, value }) => {
+                                                lines.push(`        ${JSON.stringify(`${key}: ${value}`)},`);
+                                        });
+                                        const lastIndex = lines.length - 1;
+                                        lines[lastIndex] = lines[lastIndex].replace(/,$/, '');
+                                        lines.push('    ],');
+                                }
+
+                                if (body !== undefined && body !== null && body !== '') {
+                                        let bodyString = '';
+                                        if (typeof body === 'string') {
+                                                bodyString = body;
+                                        } else {
+                                                try {
+                                                        bodyString = JSON.stringify(body);
+                                                } catch (error) {
+                                                        bodyString = String(body);
+                                                }
+                                        }
+                                        lines.push(`    CURLOPT_POSTFIELDS => ${JSON.stringify(bodyString)},`);
+                                }
+
+                                lines.push(']);', '', '$response = curl_exec($curl);');
+                                lines.push('');
+                                lines.push('if ($response === false) {');
+                                lines.push('    throw new RuntimeException(curl_error($curl));');
+                                lines.push('}');
+                                lines.push('');
+                                lines.push('curl_close($curl);');
+                                lines.push('');
+                                lines.push('echo $response;');
+
+                                return lines.join('\n');
+                        };
+
+                        const activityRequestTabDefinitions = [
+                                { id: 'http', label: 'HTTP', builder: buildHttpRequest },
+                                { id: 'javascript', label: 'JavaScript', builder: buildJavascriptRequest },
+                                { id: 'golang', label: 'Golang', builder: buildGoRequest },
+                                { id: 'python', label: 'Python', builder: buildPythonRequest },
+                                { id: 'php', label: 'PHP', builder: buildPhpRequest },
+                                { id: 'curl', label: 'cURL', builder: buildCurlCommand },
+                        ];
 
 			const activityRequestTabEntries = computed(() => {
 				const entry = selectedActivityEntry.value;


### PR DESCRIPTION
## Summary
- add request builders for Go, Python, and PHP so the activity modal can output those snippets
- register the new builders as tabs alongside the existing HTTP, JavaScript, and cURL formats

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dc701a10a0832bb26032948dacc70f