### PR TITLE
Optimize collection IO and startup performance

### DIFF
--- a/collection/persistence.go
+++ b/collection/persistence.go
@@ -1,0 +1,42 @@
+package collection
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+)
+
+var commandBufferPool = sync.Pool{
+	New: func() any {
+		return bytes.NewBuffer(make([]byte, 0, 1024))
+	},
+}
+
+func (c *Collection) persistCommand(command *Command) error {
+	if c.file == nil {
+		return fmt.Errorf("collection is closed")
+	}
+
+	buf := commandBufferPool.Get().(*bytes.Buffer)
+	buf.Reset()
+
+	if err := json.NewEncoder(buf).Encode(command); err != nil {
+		buf.Reset()
+		commandBufferPool.Put(buf)
+		return fmt.Errorf("json encode command: %w", err)
+	}
+
+	c.writeMu.Lock()
+	_, err := c.file.Write(buf.Bytes())
+	c.writeMu.Unlock()
+
+	buf.Reset()
+	commandBufferPool.Put(buf)
+
+	if err != nil {
+		return fmt.Errorf("write command: %w", err)
+	}
+
+	return nil
+}

--- a/service/service.go
+++ b/service/service.go
@@ -1,7 +1,6 @@
 package service
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -9,6 +8,8 @@ import (
 
 	"github.com/fulldump/inceptiondb/collection"
 	"github.com/fulldump/inceptiondb/database"
+	jsonv2 "github.com/go-json-experiment/json"
+	"github.com/go-json-experiment/json/jsontext"
 )
 
 type Service struct {
@@ -71,12 +72,12 @@ func (s *Service) Insert(name string, data io.Reader) error {
 		return ErrorCollectionNotFound
 	}
 
-	jsonReader := json.NewDecoder(data)
+	jsonReader := jsontext.NewDecoder(data)
 
 	for {
 		item := map[string]interface{}{}
-		err := jsonReader.Decode(&item)
-		if err == io.EOF {
+		err := jsonv2.UnmarshalDecode(jsonReader, &item)
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {


### PR DESCRIPTION
## Summary
- switch collection startup and mutation paths to jsonv2 decoding with new locking to lower contention and add safe traversal helpers
- add a pooled command persistence writer and serialize file writes to reduce allocation overhead during inserts
- parallelize database collection loading and update HTTP insert streaming to jsonv2 for faster ingest

## Testing
- make test

------
https://chatgpt.com/codex/tasks/task_e_68dff3444780832ba6ef909821102c9e