### PR TITLE
Optimize patch performance

### DIFF
--- a/api/apicollectionv1/patch.go
+++ b/api/apicollectionv1/patch.go
@@ -27,8 +27,8 @@ func patch(ctx context.Context, w http.ResponseWriter, r *http.Request) error {
 	}
 
 	patch := struct {
-		Filter map[string]interface{}
-		Patch  interface{}
+		Filter map[string]interface{} `json:"filter"`
+		Patch  json.RawMessage        `json:"patch"`
 	}{}
 	json.Unmarshal(requestBody, &patch) // TODO: handle err
 

--- a/collection/collection_benchmark_test.go
+++ b/collection/collection_benchmark_test.go
@@ -1,0 +1,45 @@
+package collection
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func BenchmarkPatch(b *testing.B) {
+	b.Run("map", func(b *testing.B) {
+		runPatchBenchmark(b, []interface{}{
+			map[string]any{"name": "Jaime"},
+			map[string]any{"name": "Pablo"},
+		})
+	})
+
+	b.Run("raw", func(b *testing.B) {
+		runPatchBenchmark(b, []interface{}{
+			json.RawMessage(`{"name":"Jaime"}`),
+			json.RawMessage(`{"name":"Pablo"}`),
+		})
+	})
+}
+
+func runPatchBenchmark(b *testing.B, patches []interface{}) {
+	Environment(func(filename string) {
+		c, err := OpenCollection(filename)
+		if err != nil {
+			b.Fatalf("open collection: %v", err)
+		}
+		defer c.Close()
+
+		row, err := c.Insert(map[string]any{"id": "1", "name": "Pablo"})
+		if err != nil {
+			b.Fatalf("insert: %v", err)
+		}
+
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			if err := c.Patch(row, patches[i%len(patches)]); err != nil {
+				b.Fatalf("patch: %v", err)
+			}
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- reuse raw JSON patch payloads to avoid redundant marshaling, diff creation, and to persist the original patch bytes for replay
- update the HTTP patch handler to forward raw patch payloads directly to the collection layer
- add benchmarks covering map-based and raw JSON patch inputs to track future performance changes

## Testing
- go test ./collection
- go test ./api/...
- go test -run='^$' -bench=Patch ./collection -benchmem


------
https://chatgpt.com/codex/tasks/task_e_68e45175fc78832b8db84cd89aa97de5