### PR TITLE
Update backlog with journal invalidation and snapshot items

### DIFF
--- a/BACKLOG.md
+++ b/BACKLOG.md
@@ -8,6 +8,8 @@
 * Index management in UI
 * BUGFIX: when document is modified to remove field from non-sparse index, it should NOT remove the field!!!
 * ~~BTree index~~
+* Allow delete and patch operations to mark journal entries as invalid so that rebuild skips invalidated records.
+* Periodically replace patch chains with snapshot inserts after N operations to limit startup replay costs.
 
 ## Should have
 
@@ -35,6 +37,7 @@
 * Ensure thread safety and improve performance with Map from standard library
 * ~~Insert multiple documents per request~~
 * Return http.StatusServiceUnavailable while loading collections
+* Insert-only collections to avoid patch overhead.
 
 ## Won't have
 


### PR DESCRIPTION
## Summary
- add backlog item to invalidate journal entries during deletes and patches
- add backlog item to periodically snapshot patch chains via inserts
- note backlog entry for insert-only collections to reduce patch overhead

## Testing
- make test *(fails: go toolchain missing `covdata` support)*

------
https://chatgpt.com/codex/tasks/task_e_6904b72b59b083248f74228b934f1e04